### PR TITLE
feat : get mysql table as name value

### DIFF
--- a/src/usecase/services/analyzer_service.go
+++ b/src/usecase/services/analyzer_service.go
@@ -75,10 +75,16 @@ func checkNilValue(in ast.Node, analyzer *model.Analyzer) {
 func (v *Visitor) Enter(in ast.Node) (ast.Node, bool) {
 
 	// TableName
-	if tableName, ok := in.(*ast.TableName); ok {
-		// TODO : sub query
+	if TableSource, ok := in.(*ast.TableSource); ok {
 		if len(v.Analyzer.TableName) == 0 {
-			v.Analyzer.TableName = tableName.Name.String()
+			if tableName, ok := TableSource.Source.(*ast.TableName); ok {
+				if len(v.Analyzer.TableName) == 0 {
+					v.Analyzer.TableName = tableName.Name.String()
+				}
+			}
+			if len(TableSource.AsName.String()) > 0 {
+				v.Analyzer.TableName = TableSource.AsName.String()
+			}
 		}
 	}
 

--- a/src/usecase/services/analyzer_service_test.go
+++ b/src/usecase/services/analyzer_service_test.go
@@ -29,7 +29,7 @@ func TestSelectQueries(t *testing.T) {
 					{
 						Type:   model.OpTypeIn,
 						Column: "c_a",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 				},
 				StmtType:       model.StmtTypeSelect,
@@ -44,12 +44,12 @@ func TestSelectQueries(t *testing.T) {
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_a",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 					{
 						Type:   model.OpTypeIn,
 						Column: "c_b",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 				},
 				StmtType:       model.StmtTypeSelect,
@@ -64,17 +64,17 @@ func TestSelectQueries(t *testing.T) {
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_a",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_b",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_c",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 				},
 				StmtType:       model.StmtTypeSelect,
@@ -82,29 +82,37 @@ func TestSelectQueries(t *testing.T) {
 			},
 		},
 		{
-			query: "select * from table_a as tb_a, (SELECT c_a ,min(c_b) as  from table_b group by c_c) as tb_b where c_a = 1 and c_b in (1) and c_c = 1",
+			query: "select * from table_a (SELECT c_a ,min(c_b) from table_b group by c_c) as tb_b where c_a = 1 and c_b in (1) and c_c = 1",
 			analyzer: model.Analyzer{
 				TableName: "table_a",
 				Operations: []model.AnalyzerOperation{
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_a",
-						Value: int64(1),
-
+						Value:  int64(1),
 					},
 					{
 						Type:   model.OpTypeIn,
 						Column: "c_b",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 					{
 						Type:   model.OpTypeEq,
 						Column: "c_c",
-						Value: int64(1),
+						Value:  int64(1),
 					},
 				},
 				StmtType:       model.StmtTypeSelect,
 				NotNullColumns: nil,
+			},
+		},
+		{
+			query: "select * from table_a as test WHERE `deleted_at` IS NULL",
+			analyzer: model.Analyzer{
+				TableName:      "test",
+				Operations:     nil,
+				StmtType:       model.StmtTypeSelect,
+				NotNullColumns: []string{"deleted_at"},
 			},
 		},
 	}
@@ -163,4 +171,3 @@ func TestInsertQueries(t *testing.T) {
 		assert.Equal(t, c.analyzer.InsertColumns, analyzer.InsertColumns)
 	}
 }
-


### PR DESCRIPTION
Allow the analyzer to get the value of a query-issued table when the alias is specified in the query as.
